### PR TITLE
Add hex head bolt data to bolts.json

### DIFF
--- a/scripts/build-dataset
+++ b/scripts/build-dataset
@@ -7,7 +7,8 @@ const path = process.env.BOLTS_PATH || 'vendor/BOLTS'
 const output = process.env.DATA_OUTPUT_PATH || '.'
 
 const nuts = yaml.parse(fs.readFileSync(`${path}/data/nut.blt`, 'utf8'))
-const bolts = yaml.parse(fs.readFileSync(`${path}/data/hex_socket.blt`, 'utf8'))
+const hexsocket_bolts = yaml.parse(fs.readFileSync(`${path}/data/hex_socket.blt`, 'utf8'))
+const hexhead_bolts = yaml.parse(fs.readFileSync(`${path}/data/hex.blt`, 'utf8'))
 
 const processClass = (spec, id, parameterMappings) => {
   const class_ = spec.classes.find(c => c.id == id)
@@ -44,18 +45,23 @@ const nutClasses = {
 const defaultNutClass = 'hexagon'
 
 const boltClasses = {
-  'headless': processClass(bolts, 'hexsocketheadcap', {
+  'headless': processClass(hexsocket_bolts, 'hexsocketheadcap', {
     diameter: 'd1',
   }),
-  'socket_head': processClass(bolts, 'hexsocketheadcap', {
+  'socket_head': processClass(hexsocket_bolts, 'hexsocketheadcap', {
     diameter: 'd1',
     head_diameter: 'd2',
     head_length: 'k'
   }),
-  'countersunk': processClass(bolts, 'hexsocketcountersunk', {
+  'countersunk': processClass(hexsocket_bolts, 'hexsocketcountersunk', {
     diameter: 'd1',
     head_diameter: 'd2',
     head_length: 'k_max'
+  }),
+  'hex_head': processClass(hexhead_bolts, 'hexbolt1', {
+    diameter: 'd1',
+    head_diameter: 'e',
+    head_length: 'k'
   }),
 }
 const defaultBoltClass = 'sockethead'


### PR DESCRIPTION
This commit adds data for hex head bolts to bolts.json.

- It renames the existing bolts dataset, which is loaded from the hex_socket.blt file, to hexsocket_bolts for clarity.
- It loads a hexhead_bolts data set from the hex.blt file.
- It adds a hex_head bolt class from the hexbolt1 section of the hexhead_bolts data, using d1 for diameter, e for head_diameter, and k for head_length.

**NOTE** This requires two patches to the upstream [boltsparts] libraries (without the first fix, the original version also fails).

1. The current version of the [boltsparts] project has a duplicate key that causes the original version of build-dataset to fail.  This is fixed in [pr25].
2. The current version of the [boltsparts] project has a duplicate key that causes this new version of build-dataset to fail.  This is fixed in [pr26].

[boltsparts]: https://github.com/boltsparts/boltsparts.git
[pr25]: https://github.com/boltsparts/boltsparts/pull/25
[pr26]: https://github.com/boltsparts/boltsparts/pull/26