### PR TITLE
Fix Incorrect Module Name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ poetry add cq-queryabolt
 
 To create a simple box with a bolt hole and a nutcatch:
 ```py
-import queryabolt
+import cq_queryabolt
 import cadquery as cq
 
 class Workplane(queryabolt.WorkplaneMixin, cq.Workplane):


### PR DESCRIPTION
Fixes the incorrect module name in the README file. The README file previously referenced 'import queryabolt', which should be 'import cq_queryabolt'